### PR TITLE
Add Force Field Name Input to Parameters Endpoint

### DIFF
--- a/inspector/backend/api/dev/api.py
+++ b/inspector/backend/api/dev/api.py
@@ -36,7 +36,11 @@ async def post_molecule_to_json(body: MoleculeToJSONBody):
 @api_router.post("/molecule/parameters", response_model=AppliedParameters)
 async def post_apply_parameters(body: ApplyParametersBody):
 
-    return label_molecule(body.molecule, force_field=ForceField(body.smirnoff_xml))
+    force_field = ForceField(
+        body.smirnoff_xml if body.smirnoff_xml is not None else body.openff_name
+    )
+
+    return label_molecule(body.molecule, force_field=force_field)
 
 
 @api_router.post("/molecule/geometry", response_model=GeometrySummary)

--- a/inspector/backend/models/molecules.py
+++ b/inspector/backend/models/molecules.py
@@ -1,6 +1,6 @@
-from typing import Literal
+from typing import Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 from inspector.library.models.molecule import RESTMolecule
 
@@ -18,10 +18,25 @@ class ApplyParametersBody(BaseModel):
     molecule: RESTMolecule = Field(
         ..., description="The molecule to apply the paramers to."
     )
-    smirnoff_xml: str = Field(
+
+    smirnoff_xml: Optional[str] = Field(
         ...,
-        description="The OFFXML serialized force field to apply to the ``molecule``.",
+        description="The SMIRNOFF serialized force field to apply to the ``molecule``. "
+        "This field is mutually exclusive with ``openff_name``.",
     )
+    openff_name: Optional[str] = Field(
+        ...,
+        description="The name of an OpenFF released force field to apply to the "
+        "``molecule``. This field is mutually exclusive with ``smirnoff_xml``.",
+    )
+
+    @validator("openff_name")
+    def _validate_mutual_exclusive(cls, v, values):
+
+        assert (v is None or values["smirnoff_xml"] is None) and (
+            v is not None or values["smirnoff_xml"] is not None
+        ), "exactly one of ``smirnoff_xml`` and ``openff_name`` must be specified."
+        return v
 
 
 class SummarizeGeometryBody(BaseModel):

--- a/inspector/tests/backend/models/test_molecules.py
+++ b/inspector/tests/backend/models/test_molecules.py
@@ -1,0 +1,24 @@
+import pytest
+from pydantic import ValidationError
+
+from inspector.backend.models.molecules import ApplyParametersBody
+from inspector.library.models.molecule import RESTMolecule
+
+
+def test_apply_parameters_body_validate(methane):
+
+    molecule = RESTMolecule.from_openff(methane)
+
+    # Mutually exclusive init
+    ApplyParametersBody(molecule=molecule, smirnoff_xml="", openff_name=None)
+    ApplyParametersBody(molecule=molecule, smirnoff_xml=None, openff_name="")
+
+    with pytest.raises(ValidationError) as error_info:
+        ApplyParametersBody(molecule=molecule, smirnoff_xml="", openff_name="")
+
+    assert "exactly one of" in str(error_info.value)
+
+    with pytest.raises(ValidationError) as error_info:
+        ApplyParametersBody(molecule=molecule, smirnoff_xml=None, openff_name=None)
+
+    assert "exactly one of" in str(error_info.value)


### PR DESCRIPTION
## Description
This PR allows a released force field name to be passed as input to the `molecule/parameters` endpoint in addition to an OFFXML contents string.

## Status
- [X] Ready to go