### PR TITLE
Add Energy Decomposition RESTful Endpoint

### DIFF
--- a/inspector/backend/models/molecules.py
+++ b/inspector/backend/models/molecules.py
@@ -80,3 +80,11 @@ class MinimizeConformerBody(_BaseForceFieldBody):
         1.0e-3,
         description="The target tolerance to converge the energy within-in [kJ / mol].",
     )
+
+
+class DecomposeEnergyBody(_BaseForceFieldBody):
+    """The expected body of the ``/molecules/energy`` POST endpoint."""
+
+    molecule: RESTMolecule = Field(
+        ..., description="The molecule whose energy should be decomposed."
+    )


### PR DESCRIPTION
## Description
This PR exposes the energy decomposition utility to the RESTful API by a new `/molecules/energy` endpoint.

## Status
- [X] Ready to go